### PR TITLE
Fixed bug in GuiceViewProvider getViewName() and added test for bug

### DIFF
--- a/src/main/java/com/vaadin/guice/server/GuiceViewProvider.java
+++ b/src/main/java/com/vaadin/guice/server/GuiceViewProvider.java
@@ -16,7 +16,7 @@
 package com.vaadin.guice.server;
 
 import com.google.common.collect.ImmutableMap;
-import com.google.gwt.thirdparty.guava.common.collect.ImmutableSortedMap;
+import com.google.common.collect.ImmutableSortedMap;
 import com.google.inject.Singleton;
 
 import com.vaadin.guice.annotation.GuiceView;
@@ -61,6 +61,8 @@ class GuiceViewProvider implements ViewProvider, SessionDestroyListener, Session
     public GuiceViewProvider(Set<Class<? extends View>> viewClasses) {
 
         viewNamesToViewClassesMap = scanForViews(viewClasses);
+        // Set of view names sorted by their natural ordering (lexicographic).
+        // This is useful for quickly looking up views by name
         viewNames = ImmutableSortedMap.copyOf(viewNamesToViewClassesMap).keySet();
 
         viewsBySessionMap = new ConcurrentHashMap<VaadinSession, Map<String, View>>();
@@ -109,10 +111,15 @@ class GuiceViewProvider implements ViewProvider, SessionDestroyListener, Session
         if (viewAndParameters == null) {
             return null;
         }
+        // Since viewNames is sorted, floor() gives us the view name
+        // less than or equal to the view and parameters string.
+        // If the view name found is less than the view and parameters
+        // string, we will test that the string starts with 'viewName/'.
         String viewName = viewNames.floor(viewAndParameters);
         if (viewName == null) {
             return null;
         }
+        // 
         if (viewAndParameters.equals(viewName)
                 || viewAndParameters.startsWith(viewName + "/")) {
             return viewName;

--- a/src/test/java/com/vaadin/guice/server/ViewProviderTest.java
+++ b/src/test/java/com/vaadin/guice/server/ViewProviderTest.java
@@ -1,0 +1,59 @@
+package com.vaadin.guice.server;
+
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+import com.vaadin.server.ServiceException;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.reflections.Reflections;
+
+import static com.vaadin.guice.server.ReflectionUtils.getGuiceUIClasses;
+import static com.vaadin.guice.server.ReflectionUtils.getGuiceViewClasses;
+import static com.vaadin.guice.server.ReflectionUtils.getViewChangeListenerClasses;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.mockito.Mockito.mock;
+import java.lang.reflect.Field;
+
+public class ViewProviderTest {
+
+    private SessionProvider sessionProvider;
+    protected CurrentUIProvider currentUIProvider;
+    protected UIScoper uiScoper;
+    protected GuiceViewProvider viewProvider;
+    protected Injector injector;
+
+    @Before
+    public void setup() throws NoSuchFieldException, IllegalAccessException {
+        sessionProvider = mock(SessionProvider.class);
+        currentUIProvider = mock(CurrentUIProvider.class);
+
+        Reflections reflections = new Reflections("com.vaadin.guice.testClasses");
+
+        VaadinModule vaadinModule = new VaadinModule(
+                sessionProvider,
+                getGuiceViewClasses(reflections),
+                getGuiceUIClasses(reflections),
+                getViewChangeListenerClasses(reflections),
+                currentUIProvider);
+
+        injector = Guice.createInjector(vaadinModule);
+
+        final Field viewProviderField = VaadinModule.class.getDeclaredField("viewProvider");
+        viewProviderField.setAccessible(true);
+        viewProvider = (GuiceViewProvider) viewProviderField.get(vaadinModule);
+    }
+
+    @Test
+    public void view_provider_get_view_name() throws ServiceException, NoSuchFieldException, IllegalAccessException {
+        assertEquals(viewProvider.getViewName("view0"), "view0");
+        assertEquals(viewProvider.getViewName("viewa/id1"), "viewa");
+        assertEquals(viewProvider.getViewName("viewaa/id2"), "viewaa");
+        assertEquals(viewProvider.getViewName("viewaaa/id3"), "viewaaa");
+        assertEquals(viewProvider.getViewName("viewb"), "viewb");
+        // getViewName() must return null if the view name is not handled by the view provider
+        assertNull(viewProvider.getViewName("viewc"));
+    }
+
+}

--- a/src/test/java/com/vaadin/guice/testClasses/View0.java
+++ b/src/test/java/com/vaadin/guice/testClasses/View0.java
@@ -1,0 +1,16 @@
+package com.vaadin.guice.testClasses;
+
+import com.vaadin.guice.annotation.GuiceView;
+import com.vaadin.navigator.View;
+import com.vaadin.navigator.ViewChangeListener.ViewChangeEvent;
+
+@GuiceView(name="view0")
+public class View0 implements View {
+
+    private static final long serialVersionUID = 1L;
+
+    @Override
+    public void enter(ViewChangeEvent event) {
+    }
+
+}

--- a/src/test/java/com/vaadin/guice/testClasses/ViewA.java
+++ b/src/test/java/com/vaadin/guice/testClasses/ViewA.java
@@ -1,0 +1,16 @@
+package com.vaadin.guice.testClasses;
+
+import com.vaadin.guice.annotation.GuiceView;
+import com.vaadin.navigator.View;
+import com.vaadin.navigator.ViewChangeListener.ViewChangeEvent;
+
+@GuiceView(name="viewa")
+public class ViewA implements View {
+
+    private static final long serialVersionUID = 1L;
+
+    @Override
+    public void enter(ViewChangeEvent event) {
+    }
+
+}

--- a/src/test/java/com/vaadin/guice/testClasses/ViewAA.java
+++ b/src/test/java/com/vaadin/guice/testClasses/ViewAA.java
@@ -1,0 +1,16 @@
+package com.vaadin.guice.testClasses;
+
+import com.vaadin.guice.annotation.GuiceView;
+import com.vaadin.navigator.View;
+import com.vaadin.navigator.ViewChangeListener.ViewChangeEvent;
+
+@GuiceView(name="viewaa")
+public class ViewAA implements View {
+
+    private static final long serialVersionUID = 1L;
+
+    @Override
+    public void enter(ViewChangeEvent event) {
+    }
+
+}

--- a/src/test/java/com/vaadin/guice/testClasses/ViewAAA.java
+++ b/src/test/java/com/vaadin/guice/testClasses/ViewAAA.java
@@ -1,0 +1,16 @@
+package com.vaadin.guice.testClasses;
+
+import com.vaadin.guice.annotation.GuiceView;
+import com.vaadin.navigator.View;
+import com.vaadin.navigator.ViewChangeListener.ViewChangeEvent;
+
+@GuiceView(name="viewaaa")
+public class ViewAAA implements View {
+
+    private static final long serialVersionUID = 1L;
+
+    @Override
+    public void enter(ViewChangeEvent event) {
+    }
+
+}

--- a/src/test/java/com/vaadin/guice/testClasses/ViewB.java
+++ b/src/test/java/com/vaadin/guice/testClasses/ViewB.java
@@ -1,0 +1,16 @@
+package com.vaadin.guice.testClasses;
+
+import com.vaadin.guice.annotation.GuiceView;
+import com.vaadin.navigator.View;
+import com.vaadin.navigator.ViewChangeListener.ViewChangeEvent;
+
+@GuiceView(name="viewb")
+public class ViewB implements View {
+
+    private static final long serialVersionUID = 1L;
+
+    @Override
+    public void enter(ViewChangeEvent event) {
+    }
+
+}


### PR DESCRIPTION
As a side note, new Reflections("com.vaadin.guice.server.testClasses") in ScopeTestBase does not seem right.
Looks like the package is now "com.vaadin.guice.testClasses".
