### PR TITLE
allow overriding injector creation in GuiceVaadinServlet

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <artifactId>guice-vaadin</artifactId>
     <packaging>jar</packaging>
     <groupId>com.vaadin</groupId>
-    <version>2.0.0-beta2</version>
+    <version>2.0.0-injector-override-support</version>
     <name>guice-vaadin</name>
     <description>
         Provides Google Guice integration for Vaadin applications.

--- a/src/main/java/com/vaadin/guice/server/GuiceVaadinServlet.java
+++ b/src/main/java/com/vaadin/guice/server/GuiceVaadinServlet.java
@@ -197,10 +197,14 @@ public class GuiceVaadinServlet extends VaadinServlet implements SessionInitList
         //sets up the basic vaadin stuff like UISetup
         VaadinModule vaadinModule = new VaadinModule(this);
 
-        this.injector = createInjector(vaadinModule, combinedModules);
+        this.injector = prepareInjector(vaadinModule, combinedModules);
 
         super.init(servletConfig);
     }
+    
+    protected Injector prepareInjector(Module... modules) {
+		return createInjector(modules);
+	}
 
     private <U> Set<Class<? extends U>> nonAbstractSubtypes(Reflections reflections, Class<U> type) {
         return reflections


### PR DESCRIPTION
This commit introduces one protected method to allow overriding injector creation in GuiceVaadinServlet.
This helps when there is already a prepared Guice Injector in the application used by some other
component and it is required to reuse its contents and state in the Vaadin app.
My original use-case: The app consists of two parts: Jersey-based REST API and Vaadin Admin UI App.
I use com.squarespace.jersey2-guice to install Guice injector into Jersey in a servlet context listener
and I need the services in that Injector to be accessible in my Vaadin Admin App.
So I put my injector creation method into a static java singleton and install it to the both places:
- via JerseyGuiceUtils.install(..) in the servlet context listener;
- via creating its child injector including the modules pre-initialized by GuiceVaadinServlet in the Vaadin app.