### PR TITLE
FIX for Java 9+ ConcurrentModificationExc when initializing ViewScope Views

### DIFF
--- a/src/main/java/com/vaadin/guice/server/UIScope.java
+++ b/src/main/java/com/vaadin/guice/server/UIScope.java
@@ -33,8 +33,14 @@ class UIScope implements Scope {
             Map<UI, Map<Key<?>, Object>> uisToScopedObjects = scopesBySession.computeIfAbsent(vaadinSession, session -> new WeakHashMap<>());
 
             final Map<Key<?>, Object> scopedObjects = getScopedObjects(uisToScopedObjects);
-
-            return (T) scopedObjects.computeIfAbsent(key, k -> provider.get());
+            
+            if(scopedObjects.containsValue(key)) {
+                return (T) scopedObjects.get(key);
+            }
+            
+            T result = provider.get();
+            scopedObjects.put(key, result);
+            return result;
         };
     }
 


### PR DESCRIPTION
Since Java 9 the behavior of HashMap::computeIfAbsent() has changed 
now: "ConcurrentModificationException - if it is detected that the mapping function modified this map"

When working with ViewScope-Views (injected into UIScope Views) a ConcurrentModificationException was thrown. This patch fixes this problem.
